### PR TITLE
Bring search_s3 method back and add an example on the notebook

### DIFF
--- a/doc/examples/EarthCube_meeting.ipynb
+++ b/doc/examples/EarthCube_meeting.ipynb
@@ -2,8 +2,8 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "differential-second",
+   "execution_count": 1,
+   "id": "iraqi-inquiry",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -14,8 +14,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "catholic-chocolate",
+   "execution_count": 2,
+   "id": "naval-honor",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,13 +25,16 @@
     "# Load UI components\n",
     "import ipyleaflet as ilfl\n",
     "from ipyleaflet import Polygon\n",
-    "import ipywidgets as iwg"
+    "import ipywidgets as iwg\n",
+    "\n",
+    "# Load S3 related module\n",
+    "from datetime import date"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "toxic-nightmare",
+   "execution_count": 3,
+   "id": "gorgeous-roman",
    "metadata": {},
    "outputs": [
     {
@@ -270,7 +273,7 @@
        "[21903 rows x 12 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -282,8 +285,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "marine-administrator",
+   "execution_count": 4,
+   "id": "amino-despite",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,17 +297,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "id": "spiritual-kitchen",
+   "execution_count": 5,
+   "id": "different-devices",
    "metadata": {},
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "10\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -521,7 +517,7 @@
        "7087 -52.255251  69.424457 -49.910379  68.703970 -54.294948  "
       ]
      },
-     "execution_count": 8,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,14 +525,22 @@
    "source": [
     "# query_pt = [-50., 69.]\n",
     "idxs = ls8.query_pathrow(69, -50)   # lat, lon\n",
-    "print(len(idxs.data.index))\n",
+    "# print(len(idxs.data.index))\n",
     "ls8.data.loc[idxs.data.index]"
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "english-voltage",
+   "metadata": {},
+   "source": [
+    "# GeoStacks UI"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "committed-vocabulary",
+   "execution_count": 6,
+   "id": "fatal-aluminum",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,17 +567,17 @@
     "    def init_panelleft(self):\n",
     "        self.ui_title = iwg.HTML(\"<h2>Drag the marker to your region of interest</h2>\")\n",
     "        self.idxs = self.spatial_index.query_pathrow(self.lat,self.lon)\n",
-    "        self.prlist = [('{:03d}/{:03d}'.format(self.spatial_index.corner_pts_df.loc[i, 'path'], \n",
-    "                                              self.spatial_index.corner_pts_df.loc[i, 'row' ]), i) for i in self.idxs]\n",
-    "        self.menuleft = iwg.Select(options=self.prlist, description='Path/Row:', rows=15)\n",
+    "        self.prlist = [('{:03d}/{:03d}'.format(self.spatial_index.data.loc[i, 'path'], \n",
+    "                                              self.spatial_index.data.loc[i, 'row' ]), i) for i in self.idxs.data.index]\n",
+    "        self.menuleft = iwg.Select(options=self.prlist, description='LS8 Path/Row:', rows=15)\n",
     "        \n",
     "    def init_map(self):\n",
     "        self.mainmap = ilfl.Map(basemap=ilfl.basemaps.Gaode.Satellite,\n",
     "                                center=[self.lat, self.lon], zoom=self.zoom)\n",
     "        self.marker = ilfl.Marker(location=[self.lat, self.lon], draggable=True)\n",
     "        self.mainmap.add_layer(self.marker)\n",
-    "        self.pr_selection = self.idxs[0]\n",
-    "        self.record = self.spatial_index.corner_pts_df.loc[self.pr_selection]\n",
+    "        self.pr_selection = self.idxs.data.index[0]\n",
+    "        self.record = self.spatial_index.data.loc[self.pr_selection]\n",
     "        self.map_polygon = Polygon(\n",
     "            locations=[(self.record.lat_UL, self.record.lon_UL), (self.record.lat_UR, self.record.lon_UR), (self.record.lat_LR, self.record.lon_LR), (self.record.lat_LL, self.record.lon_LL)],\n",
     "            color=\"blue\")\n",
@@ -599,28 +603,28 @@
     "        self.lat = self.marker.location[0]\n",
     "        self.lon = self.marker.location[-1]\n",
     "        self.idxs = self.spatial_index.query_pathrow(self.lat, self.lon)\n",
-    "        self.prlist = [('{:03d}/{:03d}'.format(self.spatial_index.corner_pts_df.loc[i, 'path'], \n",
-    "                                               self.spatial_index.corner_pts_df.loc[i, 'row']), i) for i in self.idxs]\n",
+    "        self.prlist = [('{:03d}/{:03d}'.format(self.spatial_index.data.loc[i, 'path'], \n",
+    "                                               self.spatial_index.data.loc[i, 'row']), i) for i in self.idxs.data.index]\n",
     "        self.menuleft.options = self.prlist\n",
     "        \n",
     "    # ==== map polygon update when leftmenu selection changes\n",
     "\n",
     "    def _on_menuleft_selection_changed(self, change):\n",
     "        self.pr_selection = change['new']\n",
-    "        self.record = self.spatial_index.corner_pts_df.loc[self.pr_selection]\n",
+    "        self.record = self.spatial_index.data.loc[self.pr_selection]\n",
     "        self.map_polygon.locations = [(self.record.lat_UL, self.record.lon_UL), (self.record.lat_UR, self.record.lon_UR), (self.record.lat_LR, self.record.lon_LR), (self.record.lat_LL, self.record.lon_LL)]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "green-elevation",
+   "id": "arctic-drove",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "01110c5006bf468fb074edb077b7125e",
+       "model_id": "b23f91c309ed4443bbba124e65ba6ee4",
        "version_major": 2,
        "version_minor": 0
       },
@@ -633,14 +637,296 @@
     }
    ],
    "source": [
-    "cpanel = geostacks_ui(spatial_index=ls8_index)\n",
+    "cpanel = geostacks_ui(spatial_index=ls8)\n",
     "cpanel.gen_ui()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "capital-photography",
+   "metadata": {},
+   "source": [
+    "Check the index number of the path/row selection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dying-situation",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "695"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cpanel.pr_selection"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "private-cross",
+   "metadata": {},
+   "source": [
+    "# Query the LS8 S3 bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "distinct-tomato",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>prefix</th>\n",
+       "      <th>time</th>\n",
+       "      <th>tier</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20130319_201705...</td>\n",
+       "      <td>2013-03-19</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20130522_201705...</td>\n",
+       "      <td>2013-05-22</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20130826_201705...</td>\n",
+       "      <td>2013-08-26</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20130927_201705...</td>\n",
+       "      <td>2013-09-27</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20131013_201704...</td>\n",
+       "      <td>2013-10-13</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>134</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210325_202103...</td>\n",
+       "      <td>2021-03-25</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>135</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210325_202104...</td>\n",
+       "      <td>2021-03-25</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>136</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210426_202104...</td>\n",
+       "      <td>2021-04-26</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>137</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210426_202105...</td>\n",
+       "      <td>2021-04-26</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>138</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210512_202105...</td>\n",
+       "      <td>2021-05-12</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>139 rows × 3 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                prefix        time tier\n",
+       "0    c1/L8/008/011/LC08_L1TP_008011_20130319_201705...  2013-03-19   T1\n",
+       "1    c1/L8/008/011/LC08_L1TP_008011_20130522_201705...  2013-05-22   T1\n",
+       "2    c1/L8/008/011/LC08_L1TP_008011_20130826_201705...  2013-08-26   T1\n",
+       "3    c1/L8/008/011/LC08_L1TP_008011_20130927_201705...  2013-09-27   T1\n",
+       "4    c1/L8/008/011/LC08_L1TP_008011_20131013_201704...  2013-10-13   T1\n",
+       "..                                                 ...         ...  ...\n",
+       "134  c1/L8/008/011/LC08_L1TP_008011_20210325_202103...  2021-03-25   RT\n",
+       "135  c1/L8/008/011/LC08_L1TP_008011_20210325_202104...  2021-03-25   T1\n",
+       "136  c1/L8/008/011/LC08_L1TP_008011_20210426_202104...  2021-04-26   RT\n",
+       "137  c1/L8/008/011/LC08_L1TP_008011_20210426_202105...  2021-04-26   T1\n",
+       "138  c1/L8/008/011/LC08_L1TP_008011_20210512_202105...  2021-05-12   RT\n",
+       "\n",
+       "[139 rows x 3 columns]"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "s3_prefix, scene_list = ls8.search_s3(cpanel.pr_selection)\n",
+    "scene_list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "developing-frost",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>prefix</th>\n",
+       "      <th>time</th>\n",
+       "      <th>tier</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>130</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210221_202102...</td>\n",
+       "      <td>2021-02-21</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>131</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210221_202103...</td>\n",
+       "      <td>2021-02-21</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>132</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210309_202103...</td>\n",
+       "      <td>2021-03-09</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>133</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210309_202103...</td>\n",
+       "      <td>2021-03-09</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>134</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210325_202103...</td>\n",
+       "      <td>2021-03-25</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>135</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210325_202104...</td>\n",
+       "      <td>2021-03-25</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>136</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210426_202104...</td>\n",
+       "      <td>2021-04-26</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>137</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210426_202105...</td>\n",
+       "      <td>2021-04-26</td>\n",
+       "      <td>T1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>138</th>\n",
+       "      <td>c1/L8/008/011/LC08_L1TP_008011_20210512_202105...</td>\n",
+       "      <td>2021-05-12</td>\n",
+       "      <td>RT</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                prefix        time tier\n",
+       "130  c1/L8/008/011/LC08_L1TP_008011_20210221_202102...  2021-02-21   RT\n",
+       "131  c1/L8/008/011/LC08_L1TP_008011_20210221_202103...  2021-02-21   T1\n",
+       "132  c1/L8/008/011/LC08_L1TP_008011_20210309_202103...  2021-03-09   RT\n",
+       "133  c1/L8/008/011/LC08_L1TP_008011_20210309_202103...  2021-03-09   T1\n",
+       "134  c1/L8/008/011/LC08_L1TP_008011_20210325_202103...  2021-03-25   RT\n",
+       "135  c1/L8/008/011/LC08_L1TP_008011_20210325_202104...  2021-03-25   T1\n",
+       "136  c1/L8/008/011/LC08_L1TP_008011_20210426_202104...  2021-04-26   RT\n",
+       "137  c1/L8/008/011/LC08_L1TP_008011_20210426_202105...  2021-04-26   T1\n",
+       "138  c1/L8/008/011/LC08_L1TP_008011_20210512_202105...  2021-05-12   RT"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "selection = scene_list.loc[scene_list['time'] > date(2021, 1, 1)]\n",
+    "selection"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "motivated-texas",
+   "id": "introductory-interaction",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/geostacks/geostacks.py
+++ b/geostacks/geostacks.py
@@ -180,8 +180,8 @@ class SpatialIndexLS8(SpatialIndexL3):
         # return selection_idx
 
     def search_s3(self, pr_idx):
-        s3_pathrow = '{:03d}/{:03d}'.format(self.footprint.loc[pr_idx].path,
-                                            self.footprint.loc[pr_idx].row)
+        s3_pathrow = '{:03d}/{:03d}'.format(self.data.loc[pr_idx, 'path'],
+                                            self.data.loc[pr_idx, 'row'])
         s3_prefix = 'c1/L8/' + s3_pathrow + '/LC08_L1TP_'
         # print(s3_prefix)
 


### PR DESCRIPTION
Based on the discussion from #17, I fixed the `search_s3` method and added a few lines on the `EarthCube_meeting.ipynb` showing how it works. I am not sure if we will go that far for the EC meeting, but hopefully this provides some ideas about adding a date and cloud filter in the `SpatialIndex` class. 